### PR TITLE
Noisy network

### DIFF
--- a/src/agent.rs
+++ b/src/agent.rs
@@ -132,8 +132,8 @@ impl Agent {
         let mut rng = thread_rng();
 
         let final_move = if rng.gen_range(0.0..1.0) > self.compute_epsilon() {
-            let state = Tensor::from_slice(&state.0);
-            let prediction = self.trainer.online_q_forward(&state);
+            let state = Tensor::from_slice(&state.0).unsqueeze(0);
+            let prediction = self.trainer.online_q_forward(&state).squeeze_dim(0);
             let target_move = prediction.argmax(0, false).int64_value(&[]);
             Action::from_index(target_move as u8)
         } else {

--- a/src/agent.rs
+++ b/src/agent.rs
@@ -128,7 +128,9 @@ impl Agent {
     ///
     /// The higher the epsilon of this agent, the greater the chance of a random action being chosen,
     /// this is also called as exploration/exploitation policy.
-    pub fn get_action(&self, state: &State) -> Action {
+    pub fn get_action(&mut self, state: &State) -> Action {
+        self.trainer.reset_noises();
+
         let mut rng = thread_rng();
 
         let final_move = if rng.gen_range(0.0..1.0) > self.compute_epsilon() {

--- a/src/agent.rs
+++ b/src/agent.rs
@@ -121,9 +121,7 @@ impl Agent {
     ///
     /// The higher the epsilon of this agent, the greater the chance of a random action being chosen,
     /// this is also called as exploration/exploitation policy.
-    pub fn get_action(&mut self, state: &State) -> Action {
-        self.trainer.reset_noises();
-
+    pub fn get_action(&self, state: &State) -> Action {
         let state = Tensor::from_slice(&state.0).unsqueeze(0);
         let prediction = self.trainer.online_q_forward(&state).squeeze_dim(0);
         let target_move = prediction.argmax(0, false).int64_value(&[]);
@@ -167,6 +165,9 @@ impl Agent {
         // Set the y targets, perform a gradient descent step,
         // and update the network weights.
         self.trainer.agent_learn(loss);
+
+        // Reset noise of all the NoisyLinear
+        self.trainer.reset_noises();
 
         // Update priorities in the replay buffer
         let td_errors_abs = td_errors.detach().abs().squeeze().to(Device::Cpu);

--- a/src/agent.rs
+++ b/src/agent.rs
@@ -166,9 +166,6 @@ impl Agent {
         // and update the network weights.
         self.trainer.agent_learn(loss);
 
-        // Reset noise of all the NoisyLinear
-        self.trainer.reset_noises();
-
         // Update priorities in the replay buffer
         let td_errors_abs = td_errors.detach().abs().squeeze().to(Device::Cpu);
         let td_errors_vec = Vec::<f32>::try_from(&td_errors_abs).unwrap();

--- a/src/agent.rs
+++ b/src/agent.rs
@@ -23,11 +23,11 @@ const MINI_BATCH_SIZE: usize = 64;
 /// Soft update parameter.
 const TAU: f64 = 0.001;
 /// ε-decay rate for the ε-greedy policy.
-const E_DECAY: f64 = 0.995;
+const E_DECAY: f64 = 0.9;
 /// Minimum ε value for the ε-greedy policy.
 const E_MIN: f64 = 0.01;
 /// Initial ε value for the ε-greedy policy.
-const E_START: f64 = 1.0;
+const E_START: f64 = 0.6;
 
 /// Target number of total episodes, used to calculate replay buffer beta.
 const EPISODES_MAX: i32 = 400;

--- a/src/model.rs
+++ b/src/model.rs
@@ -185,11 +185,7 @@ impl Module for DeepQNet {
         let advantage = self.advantage_fc2.forward(&advantage);
 
         // Normalize the advantage by subtracting its mean across actions.
-        let advantage_mean = if xs.size().len() == 1 {
-            advantage.mean(Kind::Float)
-        } else {
-            advantage.mean_dim(1, true, Kind::Float)
-        };
+        let advantage_mean = advantage.mean_dim(1, true, Kind::Float);
 
         // Combine Value and Advantage to compute Q(s, a).
         value + advantage - advantage_mean

--- a/src/model.rs
+++ b/src/model.rs
@@ -20,6 +20,18 @@ pub struct NoisyLinear {
     eps_out: Tensor,
 }
 
+impl Module for NoisyLinear {
+    fn forward(&self, xs: &Tensor) -> Tensor {
+        let eps_w = self.eps_out.unsqueeze(1).mm(&self.eps_in.unsqueeze(0));
+        let eps_b = &self.eps_out;
+
+        let w = &self.mu_weight + &self.sigma_weight * &eps_w;
+        let b = &self.mu_bias + &self.sigma_bias * eps_b;
+
+        xs.mm(&w.transpose(0, 1)) + b
+    }
+}
+
 /// A neural network for Dueling Deep Q-Network (Dueling DQN).
 ///
 /// This architecture splits the Q-value estimation into two streams:

--- a/src/model.rs
+++ b/src/model.rs
@@ -6,6 +6,20 @@ use crate::{
     experience::*,
 };
 
+#[derive(Debug)]
+pub struct NoisyLinear {
+    mu_weight: Tensor,
+    mu_bias: Tensor,
+    sigma_weight: Tensor,
+    sigma_bias: Tensor,
+    in_features: i64,
+    out_features: i64,
+
+    // Factorized noise vectors
+    eps_in: Tensor,
+    eps_out: Tensor,
+}
+
 /// A neural network for Dueling Deep Q-Network (Dueling DQN).
 ///
 /// This architecture splits the Q-value estimation into two streams:

--- a/src/model.rs
+++ b/src/model.rs
@@ -257,11 +257,6 @@ impl DDqnTrainer {
         self.online_q_vs.save(path).unwrap();
     }
 
-    pub fn reset_noises(&mut self) {
-        self.online_q_network.reset_noises();
-        self.target_q_network.reset_noises();
-    }
-
     /// Uses online_q_network to predict values, xs must have [`State::SIZE`] values in a single dimension.
     pub fn online_q_forward(&self, xs: &Tensor) -> Tensor {
         self.online_q_network.forward(&xs.to(DEVICE))
@@ -311,6 +306,10 @@ impl DDqnTrainer {
         loss.backward();
         // Update the weights of the online_q_network.
         self.online_q_optimizer.step();
+
+        // Reset noise of all the NoisyLinear
+        self.online_q_network.reset_noises();
+        self.target_q_network.reset_noises();
 
         // Update the weights of target_q_network using soft update.
         tch::no_grad(|| {

--- a/src/model.rs
+++ b/src/model.rs
@@ -130,6 +130,17 @@ impl DeepQNet {
             advantage_fc2: NoisyLinear::new(&vs.root() / "advantage_fc2", 128, output_size, 0.5),
         }
     }
+
+    pub fn reset_noises(&mut self) {
+        self.shared_fc1.reset_noise();
+        self.shared_fc2.reset_noise();
+
+        self.value_fc1.reset_noise();
+        self.value_fc2.reset_noise();
+
+        self.advantage_fc1.reset_noise();
+        self.advantage_fc2.reset_noise();
+    }
 }
 impl Module for DeepQNet {
     /// # Returns
@@ -222,6 +233,11 @@ impl DDqnTrainer {
     /// Saves the online_q_network var store in path.
     pub fn save_online_q_network<T: AsRef<std::path::Path>>(&self, path: T) {
         self.online_q_vs.save(path).unwrap();
+    }
+
+    pub fn reset_noises(&mut self) {
+        self.online_q_network.reset_noises();
+        self.target_q_network.reset_noises();
     }
 
     /// Uses online_q_network to predict values, xs must have [`State::SIZE`] values in a single dimension.


### PR DESCRIPTION
Noisy network implementation for layers inside DeepQNet module, replacing some linear layers. There was also a reduction in layers in DeepQNet due to overfitting.

With 100 steps the lander is already stable in the air, however, it stagnates there even after 200 more steps without evolving much, it evolves much faster, but limited, it may be an underfitting problem, but the complexity will not increase now because more changes to the network to transform it into a Rainbow net will come, and they will increase the complexity of the model.
